### PR TITLE
Add dependency graph, hash-based IDs, and activity summarization

### DIFF
--- a/ohno-cli/src/ohno_cli/_template.py
+++ b/ohno-cli/src/ohno_cli/_template.py
@@ -797,6 +797,17 @@ KANBAN_HTML_TEMPLATE = '''<!DOCTYPE html>
             }
             html += '</div>';
             html += '<div class="card-title">' + esc(task.title) + '</div>';
+
+            // Check for blocking dependencies
+            var taskDeps = (data.task_dependencies||[]).filter(function(d) { return d.task_id === task.id; });
+            var blockedByDeps = taskDeps.some(function(d) {
+                var depTask = (data.tasks||[]).find(function(t) { return t.id === d.depends_on_task_id; });
+                return depTask && depTask.status !== 'done';
+            });
+            if (blockedByDeps && task.status === 'todo') {
+                html += '<div style="font-size:0.65rem;color:var(--orange);margin-bottom:0.25rem;display:flex;align-items:center;gap:0.25rem;"><span style="opacity:0.7">&#9203;</span> Waiting on dependencies</div>';
+            }
+
             html += '<div class="card-meta">';
             if (task.task_type) {
                 html += '<span class="card-type">' + esc(task.task_type) + '</span>';


### PR DESCRIPTION
Quick wins to improve ohno task management:

- Hash-based IDs: Task/activity/dependency IDs are now content-derived SHA256 hashes instead of random UUIDs, providing collision resistance while maintaining backwards compatibility (same task-XXXXXXXX format)

- Dependency graph: Wire up existing task_dependencies table with new MCP tools (add_dependency, remove_dependency, get_task_dependencies) and filter get_session_context() to skip tasks with unfinished deps

- Activity summarization: Auto-compress activity logs when tasks complete, storing summary on task record. Adds summarize_task_activity MCP tool for manual use on long-running tasks

- Performance indexes: Add indexes on task_activity(task_id) and task_dependencies(task_id) for faster queries

- Kanban UI: Show "Waiting on dependencies" indicator on blocked todos