### PR TITLE
chore: Add story/epic status fields and ignore docs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ htmlcov/
 
 .playwright-mcp
 packages/.turbo/
+docs/

--- a/packages/ohno-core/package.json
+++ b/packages/ohno-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stevestomp/ohno-core",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Core database layer for ohno task management",
   "author": "stevestomp",
   "repository": {

--- a/packages/ohno-core/src/db.ts
+++ b/packages/ohno-core/src/db.ts
@@ -235,7 +235,7 @@ export class TaskDatabase {
    * Get tasks with optional filtering
    */
   getTasks(opts: GetTasksOptions = {}): Task[] {
-    const { status, epic_id, priority, limit = 50 } = opts;
+    const { status, epic_id, priority, story_status, epic_status, limit = 50 } = opts;
 
     let sql = GET_TASKS_WITH_JOINS;
     const conditions: string[] = ["t.status != 'archived'"];
@@ -254,6 +254,16 @@ export class TaskDatabase {
     if (priority) {
       conditions.push("e.priority = ?");
       params.push(priority);
+    }
+
+    if (story_status) {
+      conditions.push("s.status = ?");
+      params.push(story_status);
+    }
+
+    if (epic_status) {
+      conditions.push("e.status = ?");
+      params.push(epic_status);
     }
 
     sql += ` WHERE ${conditions.join(" AND ")}`;

--- a/packages/ohno-core/src/schema.ts
+++ b/packages/ohno-core/src/schema.ts
@@ -140,9 +140,11 @@ export const GET_TASKS_WITH_JOINS = `
 SELECT
   t.*,
   s.title as story_title,
+  s.status as story_status,
   e.id as epic_id,
   e.title as epic_title,
-  e.priority as epic_priority
+  e.priority as epic_priority,
+  e.status as epic_status
 FROM tasks t
 LEFT JOIN stories s ON t.story_id = s.id
 LEFT JOIN epics e ON s.epic_id = e.id
@@ -155,9 +157,11 @@ export const GET_TASK_BY_ID = `
 SELECT
   t.*,
   s.title as story_title,
+  s.status as story_status,
   e.id as epic_id,
   e.title as epic_title,
-  e.priority as epic_priority
+  e.priority as epic_priority,
+  e.status as epic_status
 FROM tasks t
 LEFT JOIN stories s ON t.story_id = s.id
 LEFT JOIN epics e ON s.epic_id = e.id

--- a/packages/ohno-core/src/types.ts
+++ b/packages/ohno-core/src/types.ts
@@ -40,9 +40,11 @@ export interface Task {
   activity_summary?: string;
   // Joined fields from relationships
   story_title?: string;
+  story_status?: TaskStatus;
   epic_id?: string;
   epic_title?: string;
   epic_priority?: Priority;
+  epic_status?: TaskStatus;
 }
 
 /**
@@ -132,6 +134,8 @@ export interface GetTasksOptions {
   status?: TaskStatus;
   epic_id?: string;
   priority?: Priority;
+  story_status?: TaskStatus;
+  epic_status?: TaskStatus;
   limit?: number;
 }
 

--- a/packages/ohno-mcp/package.json
+++ b/packages/ohno-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stevestomp/ohno-mcp",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "MCP server for ohno task management",
   "author": "stevestomp",
   "repository": {

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ohno",
-  "version": "0.5.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Task management for AI agent workflows",
   "workspaces": [


### PR DESCRIPTION
- Add story_status and epic_status to Task type
- Add story_status and epic_status filter options to GetTasksOptions
- Ignore docs/ folder in .gitignore
- Version bumps for ohno-core and ohno-mcp