### PR TITLE
fix: preserve kanban board UI state on data updates

### DIFF
--- a/packages/ohno-cli/src/template.test.ts
+++ b/packages/ohno-cli/src/template.test.ts
@@ -293,4 +293,34 @@ describe("Kanban Template", () => {
       expect(KANBAN_TEMPLATE).toContain("function getFilteredTasks()");
     });
   });
+
+  describe("State preservation on data updates (Issue #23)", () => {
+    it("should extract and parse new data from fetched HTML instead of reloading", () => {
+      // checkUpdates should extract KANBAN_DATA from HTML response via regex
+      expect(KANBAN_TEMPLATE).toContain("window\\.KANBAN_DATA");
+      expect(KANBAN_TEMPLATE).toContain("JSON.parse(dataMatch[1])");
+    });
+
+    it("should update data object in place without location.reload()", () => {
+      // Should assign new data to local variable instead of always reloading
+      expect(KANBAN_TEMPLATE).toContain("data = newData");
+      expect(KANBAN_TEMPLATE).toContain("lastSync = data.synced_at");
+    });
+
+    it("should re-render the board after data update", () => {
+      // Should call render() after updating data
+      expect(KANBAN_TEMPLATE).toMatch(/data = newData[\s\S]*?render\(\)/);
+    });
+
+    it("should re-render detail panel if open after data update", () => {
+      // Should check currentTaskId and re-render detail panel with updated data
+      expect(KANBAN_TEMPLATE).toMatch(/if \(currentTaskId\)[\s\S]*?renderDetailPanel\(task\)/);
+    });
+
+    it("should fall back to location.reload() only on parse errors", () => {
+      // Parse errors should still trigger reload as fallback
+      expect(KANBAN_TEMPLATE).toContain("} catch(parseErr) {");
+      expect(KANBAN_TEMPLATE).toContain("location.reload()");
+    });
+  });
 });

--- a/packages/ohno-cli/src/template.ts
+++ b/packages/ohno-cli/src/template.ts
@@ -685,7 +685,28 @@ export const KANBAN_TEMPLATE = `<!DOCTYPE html>
                 const r = await fetch('kanban.html?_=' + Date.now());
                 const t = await r.text();
                 const m = t.match(/"synced_at":\\s*"([^"]+)"/);
-                if (m && m[1] !== lastSync) location.reload();
+                if (m && m[1] !== lastSync) {
+                    // Extract new data without full page reload to preserve UI state
+                    const dataMatch = t.match(/window\\.KANBAN_DATA\\s*=\\s*(\\{[\\s\\S]*?\\});\\s*<\\/script>/);
+                    if (dataMatch) {
+                        try {
+                            const newData = JSON.parse(dataMatch[1]);
+                            data = newData;
+                            lastSync = data.synced_at;
+                            render();
+                            // Re-render detail panel if open with updated task data
+                            if (currentTaskId) {
+                                const task = (data.tasks||[]).find(t => t.id === currentTaskId);
+                                if (task) renderDetailPanel(task);
+                            }
+                        } catch(parseErr) {
+                            // Fall back to reload if parsing fails
+                            location.reload();
+                        }
+                    } else {
+                        location.reload();
+                    }
+                }
             } catch(e) {}
         }
 


### PR DESCRIPTION
## Summary

- Fixes the kanban board losing filter and modal state when database updates occur
- Instead of full page reload, now extracts and parses new data in-place
- Re-renders the board and any open detail panel while preserving UI state
- Falls back to reload only if JSON parsing fails

## Test plan

- [x] Added 5 regression tests in `template.test.ts`
- [x] Open kanban board, apply filters, open a task detail
- [x] From another terminal, update a task status
- [x] Verify filters remain selected and detail panel stays open with updated data

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)