### PR TITLE
feat(cli): add --story option to task create command

### DIFF
--- a/packages/ohno-cli/src/cli.ts
+++ b/packages/ohno-cli/src/cli.ts
@@ -252,6 +252,7 @@ export function createCli(): Command {
     .option("-t, --type <type>", "Task type (feature, bug, chore, spike, test)", "feature")
     .option("--description <desc>", "Task description")
     .option("-e, --estimate <hours>", "Estimated hours")
+    .option("-s, --story <id>", "Story ID to link task to")
     .action(async (title, options, command) => {
       const globalOpts = command.parent?.opts() ?? {};
       const db = await getDb(globalOpts.dir);
@@ -261,6 +262,7 @@ export function createCli(): Command {
         task_type: options.type,
         description: options.description,
         estimate_hours: options.estimate ? parseFloat(options.estimate) : undefined,
+        story_id: options.story,
       });
       db.close();
 


### PR DESCRIPTION
## Summary

- Adds `-s, --story <id>` option to the `ohno create` command
- Allows linking new tasks directly to a story during creation
- Improves workflow by eliminating the need for a separate step to assign stories

## Usage

```bash
ohno create "Implement login form" -s story-abc123
```

## Test plan

- [x] Create a task without story option (should work as before)
- [x] Create a task with `-s <story-id>` and verify it's linked to the story
- [x] Verify the task appears under the correct story in kanban board

🤖 Generated with [Claude Code](https://claude.com/claude-code)