### PR TITLE
fix(security): address multiple security vulnerabilities

### DIFF
--- a/packages/ohno-cli/src/server.ts
+++ b/packages/ohno-cli/src/server.ts
@@ -50,9 +50,6 @@ async function parseJsonBody(req: http.IncomingMessage): Promise<Record<string, 
 function sendJson(res: http.ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, {
     "Content-Type": "application/json",
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "GET, PUT, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type",
   });
   res.end(JSON.stringify(data));
 }
@@ -68,13 +65,9 @@ async function handleApiRequest(
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const method = req.method ?? "GET";
 
-  // Handle CORS preflight
+  // Handle OPTIONS request (no CORS needed for local-only server)
   if (method === "OPTIONS") {
-    res.writeHead(204, {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
-    });
+    res.writeHead(204);
     res.end();
     return true;
   }
@@ -157,7 +150,9 @@ async function handleApiRequest(
     sendJson(res, 405, { error: "Method not allowed" });
     return true;
   } catch (error) {
-    sendJson(res, 500, { error: String(error) });
+    // Log full error server-side, send generic message to client
+    console.error("API error:", error);
+    sendJson(res, 500, { error: "Internal server error" });
     return true;
   }
 }
@@ -175,17 +170,20 @@ export function createHttpServer(ohnoDir: string): http.Server {
       return;
     }
 
-    let filePath = path.join(ohnoDir, url.pathname === "/" ? "kanban.html" : url.pathname);
+    const requestedPath = path.join(ohnoDir, url.pathname === "/" ? "kanban.html" : url.pathname);
 
-    // Security: prevent directory traversal
-    if (!filePath.startsWith(ohnoDir)) {
-      res.writeHead(403);
-      res.end("Forbidden");
-      return;
-    }
-
-    // Check if file exists
-    if (!fs.existsSync(filePath)) {
+    // Security: use canonical path resolution to prevent directory traversal
+    let filePath: string;
+    try {
+      const ohnoRealPath = fs.realpathSync(ohnoDir);
+      filePath = fs.realpathSync(requestedPath);
+      if (!filePath.startsWith(ohnoRealPath + path.sep) && filePath !== ohnoRealPath) {
+        res.writeHead(403);
+        res.end("Forbidden");
+        return;
+      }
+    } catch {
+      // File doesn't exist or can't be resolved
       res.writeHead(404);
       res.end("Not Found");
       return;

--- a/packages/ohno-cli/src/template.ts
+++ b/packages/ohno-cli/src/template.ts
@@ -1,7 +1,16 @@
 /**
  * Kanban HTML template
  * Self-contained HTML with embedded styles and JavaScript
- * Note: Data comes from local SQLite (trusted source) and esc() function escapes HTML
+ *
+ * SECURITY NOTE (innerHTML usage):
+ * This template uses innerHTML for rendering, which is safe in this context because:
+ * 1. All data comes from the local SQLite database (trusted source, not user input from the web)
+ * 2. The esc() function escapes HTML special characters (&, <, >, ") in all dynamic content
+ * 3. The kanban server runs locally and is not exposed to external/untrusted users
+ * 4. No data is rendered without going through esc() first
+ *
+ * If this code is ever modified to accept untrusted input (e.g., from external APIs),
+ * consider switching to DOM methods (createElement/appendChild) or a sanitizer like DOMPurify.
  */
 
 export const KANBAN_TEMPLATE = `<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Addresses 4 security issues in the kanban server:

### #16 - Remove wildcard CORS
- Removed `Access-Control-Allow-Origin: *` headers
- The server is local-only and doesn't need cross-origin access
- Prevents malicious websites from accessing/modifying task data

### #17 - Canonical path resolution
- Replaced simple `startsWith()` check with `fs.realpathSync()`
- Properly resolves symlinks and prevents path traversal bypass attempts
- Returns 404 for non-existent files, 403 for traversal attempts

### #18 - Sanitize error messages
- API errors now log full details server-side
- Clients receive generic "Internal server error" message
- Prevents leaking internal paths, stack traces, or implementation details

### #14 - Document innerHTML security
- Added comprehensive security comment to template.ts
- Documents why innerHTML is safe in this context
- Notes what to consider if requirements change

## Test plan

- [x] All 116 tests pass
- [x] Verify kanban board still loads and functions correctly
- [x] Verify API errors return generic messages
- [x] Verify path traversal attempts return 403/404

Fixes #14, #16, #17, #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)