### PR TITLE
fix: handle special regex patterns ($') in task content

### DIFF
--- a/packages/ohno-cli/src/kanban.ts
+++ b/packages/ohno-cli/src/kanban.ts
@@ -189,5 +189,7 @@ export async function exportDatabase(dbPath: string): Promise<KanbanData> {
  */
 export function generateKanbanHtml(data: KanbanData): string {
   const jsonData = JSON.stringify(data);
-  return KANBAN_TEMPLATE.replace("{{KANBAN_DATA}}", jsonData);
+  // Use function replacement to avoid special pattern interpretation ($', $&, etc.)
+  // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
+  return KANBAN_TEMPLATE.replace("{{KANBAN_DATA}}", () => jsonData);
 }

--- a/packages/ohno-cli/src/template.test.ts
+++ b/packages/ohno-cli/src/template.test.ts
@@ -323,4 +323,71 @@ describe("Kanban Template", () => {
       expect(KANBAN_TEMPLATE).toContain("location.reload()");
     });
   });
+
+  describe("generateKanbanHtml special character handling (Issue #12)", () => {
+    it("should handle $' pattern in task content without breaking HTML", async () => {
+      const { generateKanbanHtml } = await import("./kanban.js");
+
+      // Data containing $' which is a special replacement pattern in String.replace()
+      const data = {
+        synced_at: new Date().toISOString(),
+        projects: [],
+        epics: [],
+        stories: [],
+        tasks: [{
+          id: "test-1",
+          title: "Test regex pattern",
+          description: "RegExp(r'^(\\d)\\1+$').hasMatch(pin)",
+          status: "todo",
+        }],
+        task_activity: [],
+        task_files: [],
+        task_dependencies: [],
+        stats: { total_tasks: 1, done_tasks: 0, in_progress_tasks: 0, review_tasks: 0, blocked_tasks: 0, completion_percent: 0 },
+      };
+
+      const html = generateKanbanHtml(data as any);
+
+      // HTML should be valid - script tag should close properly
+      expect(html).toContain("</script>");
+      expect(html).toContain("</html>");
+
+      // The $' pattern should be preserved in the JSON data
+      expect(html).toContain("$').hasMatch(pin)");
+
+      // Script tag should not be prematurely closed
+      const scriptStart = html.indexOf("<script>window.KANBAN_DATA");
+      const scriptEnd = html.indexOf("</script>", scriptStart);
+      const scriptContent = html.slice(scriptStart, scriptEnd);
+      expect(scriptContent).toContain("$').hasMatch(pin)");
+    });
+
+    it("should handle other special replacement patterns ($&, $`, $$)", async () => {
+      const { generateKanbanHtml } = await import("./kanban.js");
+
+      const data = {
+        synced_at: new Date().toISOString(),
+        projects: [],
+        epics: [],
+        stories: [],
+        tasks: [{
+          id: "test-1",
+          title: "Special patterns: $& $` $$",
+          description: "Test $& and $` and $$ patterns",
+          status: "todo",
+        }],
+        task_activity: [],
+        task_files: [],
+        task_dependencies: [],
+        stats: { total_tasks: 1, done_tasks: 0, in_progress_tasks: 0, review_tasks: 0, blocked_tasks: 0, completion_percent: 0 },
+      };
+
+      const html = generateKanbanHtml(data as any);
+
+      // All special patterns should be preserved literally
+      expect(html).toContain("$&");
+      expect(html).toContain("$`");
+      expect(html).toContain("$$");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the kanban board breaking when task content contains `$'` (dollar sign followed by single quote), which is common in regex patterns.

### Root Cause

JavaScript's `String.prototype.replace()` interprets special patterns in the replacement string:
- `$'` - inserts portion of string **after** the match
- `$&` - inserts the matched substring
- `` $` `` - inserts portion of string **before** the match
- `$$` - inserts a literal `$`

When generating the kanban HTML:
```javascript
KANBAN_TEMPLATE.replace("{{KANBAN_DATA}}", jsonData);
```

Any `$'` in `jsonData` was replaced with everything after `{{KANBAN_DATA}}` in the template (including `</script>`, `</html>`, etc.), breaking the HTML structure.

### Fix

Use a function replacement to avoid special pattern interpretation:
```javascript
KANBAN_TEMPLATE.replace("{{KANBAN_DATA}}", () => jsonData);
```

## Test plan

- [x] Added regression tests for `$'`, `$&`, `` $` ``, and `$$` patterns
- [x] All 118 tests pass
- [x] Create a task with description `RegExp(r'^(\d)\1+$').hasMatch(pin)` and verify kanban renders

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)